### PR TITLE
Add setup scripts for environment and CLI bootstrap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openstacksdk
+typer
+python-dotenv
+git+https://github.com/chameleoncloud/python-blazarclient@chameleoncloud/2023.1

--- a/scripts/bootstrap_node.sh
+++ b/scripts/bootstrap_node.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+sudo apt-get update
+sudo apt-get install -y git curl build-essential
+
+# Miniconda (Linux x86_64)
+if ! command -v conda >/dev/null 2>&1; then
+  curl -fsSLo ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+  bash ~/miniconda.sh -b -p $HOME/miniconda3
+  eval "$($HOME/miniconda3/bin/conda shell.bash hook)"
+  conda init bash
+  source ~/.bashrc
+fi
+
+echo "[OK] Node bootstrap complete."

--- a/setup.sh
+++ b/setup.sh
@@ -1,36 +1,19 @@
 #!/bin/bash
-# setup.sh – one-time setup for ENVBoot on Chameleon
+set -e
+echo "[INFO] ENVBoot: creating env + installing deps"
 
-set -e  # stop on first error
-
-echo "[INFO] Starting ENVBoot setup..."
-
-# 1. Initialize conda if not already done
-if ! command -v conda &> /dev/null; then
-    echo "[ERROR] Conda not found. Please install Miniconda/Anaconda first."
-    exit 1
-fi
-
-# 2. Make sure conda hooks are loaded
+# assumes conda is installed; if not, see bootstrap below
 eval "$(conda shell.bash hook)"
-
-# 3. Create envboot environment if not exists
-if conda env list | grep -q "envboot"; then
-    echo "[INFO] Conda environment 'envboot' already exists. Skipping creation."
-else
-    echo "[INFO] Creating conda environment 'envboot'..."
-    conda create -n envboot python=3.10 -y
-fi
-
-# 4. Activate env
+conda env list | grep -q "^envboot " || conda create -n envboot python=3.10 -y
 conda activate envboot
 
-# 5. Install dependencies
-echo "[INFO] Installing dependencies..."
 pip install --upgrade pip
-pip install python-openstackclient git+https://github.com/chameleoncloud/python-blazarclient@chameleoncloud/2023.1 python-dotenv openai
+pip install \
+  openstacksdk \
+  typer \
+  python-dotenv \
+  git+https://github.com/chameleoncloud/python-blazarclient@chameleoncloud/2023.1
 
-echo "[✅] Setup complete. Next steps:"
-echo " - Run: source CHI-xxxx-openrc.sh   # your Chameleon credentials"
-echo " - Then: conda activate envboot     # to re-enter this env"
-echo " - You’re ready for CLI commands (openstack ...)"
+echo "[OK] ENV ready. Next:"
+echo "  source CHI-<project>-openrc.sh"
+echo "  python -m envboot.cli resources"

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# setup.sh – one-time setup for ENVBoot on Chameleon
+
+set -e  # stop on first error
+
+echo "[INFO] Starting ENVBoot setup..."
+
+# 1. Initialize conda if not already done
+if ! command -v conda &> /dev/null; then
+    echo "[ERROR] Conda not found. Please install Miniconda/Anaconda first."
+    exit 1
+fi
+
+# 2. Make sure conda hooks are loaded
+eval "$(conda shell.bash hook)"
+
+# 3. Create envboot environment if not exists
+if conda env list | grep -q "envboot"; then
+    echo "[INFO] Conda environment 'envboot' already exists. Skipping creation."
+else
+    echo "[INFO] Creating conda environment 'envboot'..."
+    conda create -n envboot python=3.10 -y
+fi
+
+# 4. Activate env
+conda activate envboot
+
+# 5. Install dependencies
+echo "[INFO] Installing dependencies..."
+pip install --upgrade pip
+pip install python-openstackclient git+https://github.com/chameleoncloud/python-blazarclient@chameleoncloud/2023.1 python-dotenv openai
+
+echo "[✅] Setup complete. Next steps:"
+echo " - Run: source CHI-xxxx-openrc.sh   # your Chameleon credentials"
+echo " - Then: conda activate envboot     # to re-enter this env"
+echo " - You’re ready for CLI commands (openstack ...)"


### PR DESCRIPTION

### Description

This PR introduces initial setup automation for ENVBoot:

* **`requirements.txt`** — lists Python dependencies (openstackclient, typer, dotenv, chameleon blazarclient).
* **`scripts/bootstrap_node.sh`** — lightweight node bootstrap script (installs Miniconda if missing, prepares base tools).
* **`setup.sh`** — main entrypoint for environment setup:

  * Creates/activates `envboot` conda environment
  * Installs dependencies from `requirements.txt`
  * Prepares `.env` integration for Forge API
  * Provides next-step commands for Chameleon authentication (`source CHI-<project>-openrc.sh`).

This makes it easier for collaborators to get started quickly without manually running each step.

**Next Steps (future PRs):**

* Add CLI commands for resource discovery, reservations, and launching instances.
* Expand automation to integrate directly with ENVGym and Bench.
