### PR TITLE
Add AI Reserve CLI + Smoke Tests

### DIFF
--- a/envboot/cli.py
+++ b/envboot/cli.py
@@ -733,5 +733,277 @@ def case_complexity(
         typer.echo(f"Results saved to: {output_file}")
 
 
+# ==== Testing AI Reserve Cli ===== 
+# ==== AI Reserve integration helpers ====
+import sys, subprocess, re
+from typing import Tuple
+
+def _parse_first_json_block(text: str) -> dict:
+    """
+    Grab the first top-level JSON object from text.
+    Works for lines like:
+      AI Downgrade Suggestion: { ... }
+      AI Complexity Review: { ... }
+      Complexity final request: {'vcpus': 2, ...}  # single quotes -> we'll normalize
+    """
+    # Try to find a {...} block
+    m = re.search(r'\{.*\}', text, re.DOTALL)
+    if not m:
+        raise ValueError("No JSON object found in input")
+    raw = m.group(0).strip()
+
+    # Normalize single quotes to double quotes if needed (best-effort)
+    # Only do this if it looks like Python dicts (contains single quotes but not double quotes)
+    if "'" in raw and '"' not in raw:
+        raw = raw.replace("False", "false").replace("True", "true").replace("None", "null")
+        raw = re.sub(r"'", '"', raw)
+
+    return json.loads(raw)
+
+def _extract_request_from_ai_bundle(bundle: dict, mode: str) -> Tuple[ResourceRequest, float, str]:
+    """
+    Given a bundle (e.g., parsed JSON from AI output) and a mode:
+      - 'auto'      : try downgraded_request, then request_override, then mapped request-like object
+      - 'downgrade' : expect { 'downgraded_request': {...}, 'expected_duration_multiplier': (opt) }
+      - 'complexity': expect a review-like object with 'request_override' or similar
+      - 'final'     : expect a final plain request dict (vcpus, ram_gb, gpus, disk_gb?, bare_metal?)
+    Returns (ResourceRequest, duration_multiplier, why/explanation string)
+    """
+    mode = mode.lower()
+
+    def to_req(d: dict) -> ResourceRequest:
+        return ResourceRequest(
+            vcpus=int(d.get("vcpus", 2)),
+            ram_gb=int(d.get("ram_gb", 4)),
+            gpus=int(d.get("gpus", 0)),
+            disk_gb=int(d.get("disk_gb", 20)),
+            bare_metal=bool(d.get("bare_metal", False)),
+        )
+
+    # If it's the Downgrade Advisor JSON
+    if mode in ("auto", "downgrade") and "downgraded_request" in bundle:
+        req = to_req(bundle["downgraded_request"])
+        dur_mult = float(bundle.get("expected_duration_multiplier", 1.0))
+        why = bundle.get("why", "AI Downgrade Advisor output")
+        return req, dur_mult, why
+
+    # If it's a Complexity Review JSON
+    if mode in ("auto", "complexity") and ("request_override" in bundle or "tier_override" in bundle):
+        chosen = bundle.get("request_override")
+        if chosen is None:
+            # Fall back to something that looks like a request (some variants return the original mapping)
+            # This is permissive on purpose.
+            for k in ("final_request", "mapped_request", "suggested_request"):
+                if k in bundle:
+                    chosen = bundle[k]
+                    break
+        if chosen is None:
+            raise ValueError("No request_override/final/mapped request found in complexity bundle")
+        req = to_req(chosen)
+        dur_mult = 1.0
+        why = bundle.get("why", "AI Complexity Review output")
+        return req, dur_mult, why
+
+    # If it's just a final/plain request dict (e.g., from a line: Complexity final request: {...})
+    if mode in ("auto", "final"):
+        # Heuristic: if the object itself looks like a request
+        keys = set(bundle.keys())
+        if {"vcpus", "ram_gb", "gpus"} <= keys:
+            req = to_req(bundle)
+            return req, 1.0, "Final request (plain)"
+        # Or nested under a known field name
+        for k in ("final_request", "request", "mapped_request", "downgraded_request"):
+            if isinstance(bundle.get(k), dict) and {"vcpus", "ram_gb", "gpus"} <= set(bundle[k].keys()):
+                req = to_req(bundle[k])
+                # If we pulled a downgraded_request here, try to honor duration multiplier if present
+                dur_mult = float(bundle.get("expected_duration_multiplier", 1.0))
+                why = f"Final ({k})"
+                return req, dur_mult, why
+
+    # If we reach here, we couldn't recognize shape
+    raise ValueError("Unrecognized AI bundle structure for mode=" + mode)
+
+def _load_ai_bundle_from_source(source: str, mode: str) -> dict:
+    """
+    Load AI bundle either by running forge.py (stdout parsing) or from a JSON file path.
+    Anchors per mode:
+      downgrade : "AI Downgrade Suggestion:"  (fallbacks: "AI Downgrade Advisor", "Downgraded request:")
+      final     : "Complexity final request:" (fallbacks: "AI Complexity Review (GPU-heavy):", last JSON-ish block)
+      complexity: "AI Complexity Review:"     (diagnostic; may have request_override = null)
+    """
+    def _find_first(pattern: str, text: str) -> str | None:
+        m = re.search(pattern, text, re.DOTALL | re.IGNORECASE)
+        return m.group(1) if m else None
+
+    if source == "forge":
+        proc = subprocess.run(
+            [sys.executable, "envboot/forge.py"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True
+        )
+        out = proc.stdout
+
+        m = mode.lower()
+
+        if m == "downgrade":
+            # Primary: full suggestion object with multiplier/why
+            block = _find_first(r"AI\s+Downgrade\s+Suggestion:\s*(\{.*?\})", out)
+            if block:
+                return _parse_first_json_block(block)
+
+            # Fallback 1: advisor variants, e.g. "AI Downgrade Advisor (looser RAM cuts): { ... }"
+            block = _find_first(r"AI\s+Downgrade\s+Advisor[^\n:]*:\s*(\{.*?\})", out)
+            if block:
+                return _parse_first_json_block(block)
+
+            # Fallback 2: plain downgraded request (note: no multiplier/why here)
+            block = _find_first(r"Downgraded\s+request:\s*(\{.*?\})", out)
+            if block:
+                return _parse_first_json_block(block)
+
+            raise ValueError("Could not locate a downgrade block in forge output")
+
+        if m == "complexity":
+            block = _find_first(r"AI\s+Complexity\s+Review:\s*(\{.*?\})", out)
+            if block:
+                return _parse_first_json_block(block)
+            raise ValueError("Could not locate 'AI Complexity Review' JSON in forge output")
+
+        # default: final/plain request
+        if m in ("final", "auto"):
+            # Primary: “Complexity final request: {...}”
+            block = _find_first(r"Complexity\s+final\s+request:\s*(\{.*?\})", out)
+            if block:
+                return _parse_first_json_block(block)
+
+            # Fallback: accept a GPU-heavy final-like line as a plain request
+            block = _find_first(r"AI\s+Complexity\s+Review\s*\(GPU-heavy\):\s*(\{.*?\})", out)
+            if block:
+                return _parse_first_json_block(block)
+
+            # Last resort: take the LAST JSON-ish object in stdout
+            candidates = list(re.finditer(r"\{.*?\}", out, re.DOTALL))
+            if not candidates:
+                raise ValueError("Could not find any JSON block in forge output")
+            return _parse_first_json_block(candidates[-1].group(0))
+
+        # Unknown mode
+        raise ValueError(f"Unknown mode: {mode}")
+
+    # Otherwise, JSON file path
+    with open(source, "r") as f:
+        return json.load(f)
+
+
+@app.command("ai-reserve")
+def ai_reserve(
+    source: str = typer.Option("forge", help="Source of AI output: 'forge' to run envboot/forge.py, or path to a JSON file"),
+    mode: str = typer.Option("final", help="Which AI output to consume: 'final', 'downgrade', or 'complexity' (or 'auto')"),
+    name: str = typer.Option("envboot-ai", help="Lease name prefix"),
+    repo_path: str = typer.Option(".", help="Repo path (only used for default duration if AI doesn't specify)"),
+    duration_hours: float = typer.Option(None, help="Override reservation duration in hours"),
+    start_in_minutes: int = typer.Option(2, help="Start the reservation in N minutes"),
+    lookahead_hours: int = typer.Option(72, help="For parity with other flows; unused here but kept for symmetry"),
+    output_file: str = typer.Option(None, "--output", help="JSON output file path"),
+):
+    """
+    Create a lease directly from AI-produced JSON (either by running forge.py or reading a file).
+    - Chooses a ResourceRequest from the AI bundle (downgraded_request / request_override / final request).
+    - Applies expected_duration_multiplier if present (for downgrade outputs).
+    - Falls back to repo-derived default duration when not provided.
+    """
+    typer.echo("=== AI Reserve ===")
+    try:
+        bundle = _load_ai_bundle_from_source(source, mode.lower())
+        typer.echo(f"[ok] Loaded AI bundle from {source} in mode={mode}")
+    except Exception as e:
+        typer.echo(f"Failed to load AI bundle: {e}")
+        raise typer.Exit(1)
+
+    try:
+        req, dur_mult, why = _extract_request_from_ai_bundle(bundle, mode.lower())
+        typer.echo(f"[ok] Extracted request: {req} (multiplier={dur_mult})")
+    except Exception as e:
+        typer.echo(f"Failed to interpret AI bundle: {e}")
+        raise typer.Exit(1)
+
+    typer.echo(f"AI chose: {req.vcpus} vCPUs, {req.ram_gb} GB RAM, {req.gpus} GPUs, disk {req.disk_gb} GB, bare_metal={req.bare_metal}")
+    typer.echo(f"Why: {why}")
+
+    # Decide duration
+    if duration_hours is not None:
+        base_duration = float(duration_hours)
+    else:
+        # Use your existing complexity-derived default as a fallback
+        try:
+            from .analysis import analyze_repo_complexity, get_default_duration_hours
+            tier = analyze_repo_complexity(repo_path)
+            base_duration = get_default_duration_hours(tier)
+        except Exception:
+            base_duration = 4.0  # safe default
+    adjusted_duration = max(0.5, base_duration * float(dur_mult))
+
+    start_time = datetime.now(timezone.utc) + timedelta(minutes=start_in_minutes)
+    end_time = start_time + timedelta(hours=adjusted_duration)
+
+    plan = ReservationPlan(
+        zone="current",
+        start=start_time,
+        end=end_time,
+        flavor="auto",
+        count=1
+    )
+
+    typer.echo("Creating Blazar reservation...")
+    try:
+        lease = create_reservation(plan, req, f"{name}-{int(time.time())}")
+        typer.echo(f"[ok] Reservation call returned lease id={plan.lease_id}")
+    except Exception as e:
+        typer.echo(f"Reservation failed: {e}")
+        raise typer.Exit(1)
+
+    # SU estimates (reusing your heuristic host caps)
+    host_caps = {"vcpus": 48, "gpus": 4}
+    su_per_hour = estimate_su_per_hour(req, host_caps)
+    su_total = su_per_hour * adjusted_duration
+
+    # Output
+    typer.echo("\n=== Results ===")
+    typer.echo(f"Reservation created: {plan.lease_id}")
+    typer.echo(f"Zone: {plan.zone}")
+    typer.echo(f"Start: {plan.start}")
+    typer.echo(f"End: {plan.end}")
+    typer.echo(f"Flavor: {plan.flavor}")
+    typer.echo(f"Duration: {adjusted_duration:.2f} h (base {base_duration:.2f} h × multiplier {dur_mult:.2f})")
+    typer.echo(f"SU cost: {su_total:.4f}")
+
+    if output_file:
+        result = {
+            "case": "ai_reserve",
+            "ai_mode": mode,
+            "ai_source": source,
+            "ai_why": why,
+            "request": req.__dict__,
+            "reservation": {
+                "lease_id": plan.lease_id,
+                "reservation_id": plan.reservation_id,
+                "zone": plan.zone,
+                "start": plan.start.isoformat(),
+                "end": plan.end.isoformat(),
+                "flavor": plan.flavor,
+            },
+            "duration_hours": adjusted_duration,
+            "su_estimate_per_hour": su_per_hour,
+            "su_estimate_total": su_total,
+        }
+        with open(output_file, "w") as f:
+            json.dump(result, f, indent=2, default=str)
+        typer.echo(f"Results saved to: {output_file}")
+
+
 def main():
     app()
+    
+if __name__ == "__main__":
+    main()

--- a/envboot/forge.py
+++ b/envboot/forge.py
@@ -80,7 +80,7 @@ CPU ~6 vCPUs. No GPU needed. Disk ~1 GB plus assets (~0.5 GB). Network minimal."
     print("AI Downgrade Suggestion:", json.dumps(dg, indent=2))
 
 
-    # --- Test AI Complexity Review ---
+    # # --- Test AI Complexity Review ---
     signals = {"gpu_frameworks": ["torch"], "cuda_files": 0, "final_score": 5, "tier": "HEAVY"}
     mapped_request = {"vcpus": 8, "ram_gb": 32, "gpus": 1, "disk_gb": 80, "bare_metal": False}
 
@@ -98,7 +98,7 @@ CPU ~6 vCPUs. No GPU needed. Disk ~1 GB plus assets (~0.5 GB). Network minimal."
     final_request = ai_complexity_review(signals, mapped)
     print("Complexity final request:", final_request)
 
-    # Example downgrade
+    # # Example downgrade
     original_req = mapped
     policy = {"max_vcpu_reduction_ratio": 0.5, "max_ram_reduction_ratio": 0.2, "max_duration_increase_ratio": 2.0}
     tier_name = tier.value
@@ -106,6 +106,8 @@ CPU ~6 vCPUs. No GPU needed. Disk ~1 GB plus assets (~0.5 GB). Network minimal."
     print("Downgraded request:", downgraded)
 
 
+
+    # --- Test AI Complexity Review with signals ---
     # GPU-heavy repo
     signals = {"gpu_frameworks": ["torch"], "cuda_files": 0, "final_score": 5, "tier": "HEAVY"}
     mapped_request = {"vcpus": 8, "ram_gb": 32, "gpus": 1, "disk_gb": 80, "bare_metal": False}

--- a/envboot/prompt.py
+++ b/envboot/prompt.py
@@ -66,7 +66,10 @@ Return ONLY a JSON object with this exact schema.
 
 def prompt_mock_api(resource_json: str) -> str:
     # resource_json should already be valid JSON string
-    return f"""You are an allocation agent. Return ONLY JSON. The first character MUST be '{{'.
+    return f"""You are an allocation agent. Return ONLY JSON. Format: output 
+**one single-line, minified JSON object** (no newlines or indentation; no spaces 
+after commas/colons); use double quotes for all keys/strings; JSON booleans `true/false` 
+and `null`; numeric fields must be numbers. The first character MUST be '{{'.
 
 INPUT mock API (current node + optional alternatives):
 {resource_json}
@@ -96,7 +99,10 @@ Return ONLY JSON with this schema:
 """
 
 def prompt_ai_analysis(report_text: str) -> str:
-    return f"""You are an analyzer. Return ONLY JSON. The first character MUST be '{{'.
+    return f"""You are an analyzer. Return ONLY JSON. Format: output 
+**one single-line, minified JSON object** (no newlines or indentation; no spaces 
+after commas/colons); use double quotes for all keys/strings; JSON booleans `true/false` 
+and `null`; numeric fields must be numbers. The first character MUST be '{{'.
 
 Analyze the text and infer minimum hardware plus a small safety headroom.
 
@@ -135,7 +141,10 @@ def build_prompt(task: str, **kwargs) -> str:
 # ---------- NEW PROMPTS FOR DOWNGRADE + COMPLEXITY ----------
 
 def prompt_downgrade_advisor(original_req_json: str, policy_json: str, tier: str) -> str:
-    return f"""You are a downgrading advisor. Return ONLY JSON. First char MUST be '{{'.
+    return f"""You are a downgrading advisor. Return ONLY JSON. Format: output 
+**one single-line, minified JSON object** (no newlines or indentation; no spaces 
+after commas/colons); use double quotes for all keys/strings; JSON booleans `true/false` 
+and `null`; numeric fields must be numbers. First char MUST be '{{'.
 
 Goal: propose a downgraded ResourceRequest that RESPECTS the policy caps.
 
@@ -166,7 +175,10 @@ Return ONLY:
 """
 
 def prompt_complexity_review(signals_json: str, mapped_req_json: str) -> str:
-    return f"""You are a reviewer. Return ONLY JSON. First char MUST be '{{'.
+    return f"""You are a reviewer. Return ONLY JSON. Format: output 
+**one single-line, minified JSON object** (no newlines or indentation; no spaces 
+after commas/colons); use double quotes for all keys/strings; JSON booleans `true/false` 
+and `null`; numeric fields must be numbers. First char MUST be '{{'.
 
 Task: Review deterministic complexity signals and the mapped request. Optionally suggest an override.
 

--- a/scripts/smoke_ai_reserve.sh
+++ b/scripts/smoke_ai_reserve.sh
@@ -1,0 +1,245 @@
+#!/bin/sh
+#
+# Smoke test for envboot CLI AI reserve flows.
+#
+# Usage:
+#   scripts/smoke_ai_reserve.sh [--output-prefix /tmp/envboot-ai]
+#
+# Notes:
+# - Runs a suite of checks:
+#     1) FINAL (SIMPLE) using forge source
+#     2) DOWNGRADE (GPU/HEAVY) using forge source with ENVBOOT_FAKE_GPU=1
+#     3) CPU-only downgrade (no GPU path) via forge source
+#     4) GPU→CPU allowed downgrade using cases-downgrade on a fake GPU repo
+#     5) Smoke-test required: fail and succeed variants using cases-downgrade
+#     6) Complexity review mode parsing
+# - Asserts on stdout using grep/awk; exits non-zero on failure.
+# - If --output-prefix is provided, writes CLI JSON outputs and stdout logs under that prefix.
+# - Requires FORGE_API_KEY and valid OpenStack auth for reservation creation.
+
+set -eu
+
+OUT_PREFIX=""
+if [ "${1-}" = "--output-prefix" ] && [ -n "${2-}" ]; then
+  OUT_PREFIX="$2"
+  shift 2
+fi
+
+ok() { printf "[OK] %s\n" "$1"; }
+fail() { printf "[FAIL] %s\n" "$1"; }
+
+overall_rc=0
+
+run_final_simple() {
+  name="FINAL (SIMPLE)"
+  cmd="python -m envboot.cli ai-reserve --source forge --mode final"
+  if [ -n "$OUT_PREFIX" ]; then
+    out_json="${OUT_PREFIX}-final.json"
+    cmd="$cmd --output $out_json"
+  fi
+
+  if [ -n "$OUT_PREFIX" ]; then
+    stdout_log="${OUT_PREFIX}-final.stdout"
+    # shellcheck disable=SC2090
+    sh -c "$cmd" >"$stdout_log" 2>&1 || true
+    output=$(cat "$stdout_log")
+  else
+    # Capture stdout
+    # shellcheck disable=SC2090
+    output=$(sh -c "$cmd" 2>&1 || true)
+  fi
+
+  rc=0
+  echo "$output" | grep -q "AI chose: 2 vCPUs" || { fail "$name: expected 'AI chose: 2 vCPUs'"; rc=1; }
+  echo "$output" | grep -q " 0 GPUs" || { fail "$name: expected '0 GPUs'"; rc=1; }
+  echo "$output" | grep -q "Flavor: g1.kvm.2" || { fail "$name: expected 'Flavor: g1.kvm.2'"; rc=1; }
+  echo "$output" | grep -q "\u00d7 multiplier 1.00" || echo "$output" | grep -q "× multiplier 1.00" || { fail "$name: expected '× multiplier 1.00'"; rc=1; }
+
+  if [ $rc -eq 0 ]; then ok "$name"; else overall_rc=1; fi
+}
+
+run_downgrade_gpu() {
+  name="DOWNGRADE (GPU/HEAVY)"
+  cmd="ENVBOOT_FAKE_GPU=1 python -m envboot.cli ai-reserve --source forge --mode downgrade"
+  if [ -n "$OUT_PREFIX" ]; then
+    out_json="${OUT_PREFIX}-downgrade.json"
+    cmd="$cmd --output $out_json"
+  fi
+
+  if [ -n "$OUT_PREFIX" ]; then
+    stdout_log="${OUT_PREFIX}-downgrade.stdout"
+    # shellcheck disable=SC2090
+    sh -c "$cmd" >"$stdout_log" 2>&1 || true
+    output=$(cat "$stdout_log")
+  else
+    # shellcheck disable=SC2090
+    output=$(sh -c "$cmd" 2>&1 || true)
+  fi
+
+  rc=0
+  echo "$output" | grep -q "AI chose: 8 vCPUs" || { fail "$name: expected 'AI chose: 8 vCPUs'"; rc=1; }
+  echo "$output" | grep -q " 1 GPUs" || { fail "$name: expected '1 GPUs'"; rc=1; }
+  echo "$output" | grep -q "Flavor: g1.kvm.1" || { fail "$name: expected 'Flavor: g1.kvm.1'"; rc=1; }
+
+  # Extract the multiplier from the Duration line and assert > 1.0 and <= 2.0
+  mult=$(printf "%s\n" "$output" | grep '^Duration:' | tail -n 1 | awk -F'multiplier ' 'NF>1{val=$2; sub(/[^0-9.].*$/, "", val); print val}')
+  if [ -z "${mult}" ]; then
+    fail "$name: could not parse duration multiplier"
+    rc=1
+  else
+    # Use awk for floating-point comparison: >1.0 and <=2.0
+    echo "$mult" | awk 'BEGIN{ok=0} {if ($1>1.0 && $1<=2.0) ok=1} END{exit ok?0:1}' || { fail "$name: multiplier $mult not in (1.0, 2.0]"; rc=1; }
+  fi
+
+  if [ $rc -eq 0 ]; then ok "$name"; else overall_rc=1; fi
+}
+
+run_downgrade_cpu_only() {
+  name="DOWNGRADE (CPU-only)"
+  cmd="python -m envboot.cli ai-reserve --source forge --mode downgrade"
+  if [ -n "$OUT_PREFIX" ]; then
+    out_json="${OUT_PREFIX}-downgrade-cpu.json"
+    cmd="$cmd --output $out_json"
+  fi
+
+  if [ -n "$OUT_PREFIX" ]; then
+    stdout_log="${OUT_PREFIX}-downgrade-cpu.stdout"
+    sh -c "$cmd" >"$stdout_log" 2>&1 || true
+    output=$(cat "$stdout_log")
+  else
+    output=$(sh -c "$cmd" 2>&1 || true)
+  fi
+
+  rc=0
+  # Just sanity: parsing worked and we chose something
+  echo "$output" | grep -q "\[ok\] Loaded AI bundle" || { fail "$name: loader did not report ok"; rc=1; }
+  echo "$output" | grep -q "AI chose:" || { fail "$name: missing 'AI chose:' line"; rc=1; }
+  echo "$output" | grep -q "Flavor:" || { fail "$name: missing 'Flavor:' line"; rc=1; }
+  if [ $rc -eq 0 ]; then ok "$name"; else overall_rc=1; fi
+}
+
+make_fake_gpu_repo() {
+  repo="$1"
+  mkdir -p "$repo" || true
+  # Minimal GPU-ish signals
+  printf "torch==2.2.0\n" >"$repo/requirements.txt"
+  : >"$repo/kernel.cu"
+}
+
+run_cases_downgrade_gpu_to_cpu() {
+  name="CASES DOWNGRADE (GPU→CPU allowed)"
+  repo="/tmp/gpu-smoke"
+  make_fake_gpu_repo "$repo"
+  out_json=""
+  cmd="python -m envboot.cli cases-downgrade $repo --allow-gpu-downgrade True --smoke-test 'python -c \"print(1)\"'"
+  if [ -n "$OUT_PREFIX" ]; then
+    out_json="${OUT_PREFIX}-cases-downgrade.json"
+    cmd="$cmd --output $out_json"
+  fi
+
+  # Run and capture RC
+  if [ -n "$OUT_PREFIX" ]; then
+    stdout_log="${OUT_PREFIX}-cases-downgrade.stdout"
+    sh -c "$cmd" >"$stdout_log" 2>&1
+    rc_cmd=$?
+    output=$(cat "$stdout_log")
+  else
+    output=$(sh -c "$cmd" 2>&1)
+    rc_cmd=$?
+  fi
+
+  rc=0
+  if [ $rc_cmd -ne 0 ]; then
+    fail "$name: command failed ($rc_cmd)"
+    overall_rc=1
+    return
+  fi
+
+  # If we have a JSON output, assert GPU dropped to 0
+  if [ -n "$out_json" ] && [ -f "$out_json" ]; then
+    py="import json,sys;d=json.load(open(sys.argv[1]));orig=d['inputs']['original_request']['gpus'];down=d['inputs']['downgraded_request']['gpus'];print(orig,down);exit(0 if (orig>=1 and down==0) else 1)"
+    if python -c "$py" "$out_json"; then
+      :
+    else
+      fail "$name: expected original gpus>=1 and downgraded gpus==0"
+      rc=1
+    fi
+  else
+    # Fallback: look for success messages
+    echo "$output" | grep -q "Downgrade applied successfully" || { fail "$name: downgrade not applied"; rc=1; }
+  fi
+
+  if [ $rc -eq 0 ]; then ok "$name"; else overall_rc=1; fi
+}
+
+run_cases_downgrade_smoke_fail() {
+  name="CASES DOWNGRADE (smoke-test required fail)"
+  cmd="python -m envboot.cli cases-downgrade . --smoke-test 'false'"
+  if [ -n "$OUT_PREFIX" ]; then
+    stdout_log="${OUT_PREFIX}-cases-downgrade-fail.stdout"
+    sh -c "$cmd" >"$stdout_log" 2>&1; rc_cmd=$?
+    output=$(cat "$stdout_log")
+  else
+    output=$(sh -c "$cmd" 2>&1); rc_cmd=$?
+  fi
+  if [ $rc_cmd -ne 0 ]; then
+    ok "$name"
+  else
+    fail "$name: expected non-zero exit due to smoke test failure"; overall_rc=1
+  fi
+}
+
+run_cases_downgrade_smoke_pass() {
+  name="CASES DOWNGRADE (smoke-test required pass)"
+  cmd="python -m envboot.cli cases-downgrade . --smoke-test 'python -c \"print(1)\"'"
+  if [ -n "$OUT_PREFIX" ]; then
+    stdout_log="${OUT_PREFIX}-cases-downgrade-pass.stdout"
+    sh -c "$cmd" >"$stdout_log" 2>&1; rc_cmd=$?
+    output=$(cat "$stdout_log")
+  else
+    output=$(sh -c "$cmd" 2>&1); rc_cmd=$?
+  fi
+  if [ $rc_cmd -eq 0 ]; then
+    ok "$name"
+  else
+    fail "$name: expected zero exit with passing smoke test"; overall_rc=1
+  fi
+}
+
+run_complexity_mode() {
+  name="AI-RESERVE (complexity mode)"
+  cmd="python -m envboot.cli ai-reserve --source forge --mode complexity"
+  if [ -n "$OUT_PREFIX" ]; then
+    out_json="${OUT_PREFIX}-complexity.json"
+    cmd="$cmd --output $out_json"
+  fi
+  if [ -n "$OUT_PREFIX" ]; then
+    stdout_log="${OUT_PREFIX}-complexity.stdout"
+    sh -c "$cmd" >"$stdout_log" 2>&1; rc_cmd=$?
+    output=$(cat "$stdout_log")
+  else
+    output=$(sh -c "$cmd" 2>&1); rc_cmd=$?
+  fi
+  rc=0
+  if [ $rc_cmd -ne 0 ]; then
+    fail "$name: command failed ($rc_cmd)"; overall_rc=1; return
+  fi
+  echo "$output" | grep -q "AI chose:" || { fail "$name: missing 'AI chose:' line"; rc=1; }
+  if [ $rc -eq 0 ]; then ok "$name"; else overall_rc=1; fi
+}
+
+run_final_simple
+run_downgrade_gpu
+run_downgrade_cpu_only
+run_cases_downgrade_gpu_to_cpu
+run_cases_downgrade_smoke_fail
+run_cases_downgrade_smoke_pass
+run_complexity_mode
+
+if [ $overall_rc -eq 0 ]; then
+  printf "\nAll smoke tests passed.\n"
+else
+  printf "\nSome smoke tests failed.\n" >&2
+fi
+
+exit $overall_rc


### PR DESCRIPTION

**Changes**

* New `ai-reserve` command in CLI to create reservations directly from `forge.py` outputs
* Robust parsing of AI outputs (`final`, `downgrade`, `complexity`)
* Logging of chosen resources and multipliers
* Added `scripts/smoke_ai_reserve.sh` to cover main flows with real leases
* Validated Case 3 (downgrade) and Case 4 (complexity) against expectations

**Testing**

* Ran `ai-reserve` in both `--mode final` and `--mode downgrade` with/without `ENVBOOT_FAKE_GPU`
* Confirmed reservations were created successfully with correct resources and duration multipliers
* Ran `scripts/smoke_ai_reserve.sh` to validate all supported flows

